### PR TITLE
Set IP to 0.0.0.0 when unknown

### DIFF
--- a/app/Traits/CaptureIpTrait.php
+++ b/app/Traits/CaptureIpTrait.php
@@ -34,7 +34,7 @@ class CaptureIpTrait {
         }
         else
         {
-            $ipAddress = 'UNKNOWN';
+            $ipAddress = '0.0.0.0';
         }
         return $ipAddress;
     }


### PR DESCRIPTION
Set IP to 0.0.0.0 when unknown. Previously it was set to 'UNKNOWN' and that raised an exception when attempting to store that value as an IP in the database.